### PR TITLE
Implemented callback queue methods for blocks

### DIFF
--- a/Sources/CKAcceptSharesOperation.swift
+++ b/Sources/CKAcceptSharesOperation.swift
@@ -32,6 +32,12 @@ public class CKAcceptSharesOperation: CKOperation {
         super.finishOnCallbackQueue(error: error)
     }
     
+    func perShare(shareMetadata: CKShareMetadata, acceptedShare: CKShare?, error: Error?){
+        callbackQueue.async {
+            self.perShareCompletionBlock?(shareMetadata, nil, nil)
+        }
+    }
+
     override func performCKOperation() {
         
         let operationURLRequest = CKAcceptSharesURLRequest(shortGUIDs: shortGUIDs)
@@ -39,7 +45,9 @@ public class CKAcceptSharesOperation: CKOperation {
         operationURLRequest.accountInfoProvider = CloudKit.shared.defaultAccount
         
         operationURLRequest.completionBlock = { (result) in
-            
+            if(self.isCancelled){
+                return
+            }
             switch result {
             case .success(let dictionary):
                 
@@ -48,9 +56,8 @@ public class CKAcceptSharesOperation: CKOperation {
                     // Parse JSON into CKRecords
                     for resultDictionary in resultsDictionary {
                         if let shareMetadata = CKShareMetadata(dictionary: resultDictionary) {
-                            self.perShareCompletionBlock?(shareMetadata, nil, nil)
+                            self.perShare(shareMetadata: shareMetadata, acceptedShare: nil, error: nil)
                         }
-                        
                     }
                 }
                 
@@ -63,6 +70,7 @@ public class CKAcceptSharesOperation: CKOperation {
         
         operationURLRequest.performRequest()
     }
+
 
     
 }

--- a/Sources/CKDiscoverAllUserIdentitiesOperation.swift
+++ b/Sources/CKDiscoverAllUserIdentitiesOperation.swift
@@ -28,6 +28,11 @@ public class CKDiscoverAllUserIdentitiesOperation : CKOperation {
         super.finishOnCallbackQueue(error: error)
     }
     
+    func discovered(userIdentity: CKUserIdentity){
+        callbackQueue.async {
+            self.userIdentityDiscoveredBlock?(userIdentity)
+        }
+    }
     
     override func performCKOperation() {
         
@@ -35,14 +40,9 @@ public class CKDiscoverAllUserIdentitiesOperation : CKOperation {
       
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url) { (dictionary, error) in
             
-            // Check if cancelled
-            // (Should no longer be needed)
-//            if self.isCancelled {
-//                // Send Cancelled Error to CompletionBlock
-//                let cancelError = NSError(domain: CKErrorDomain, code: CKErrorCode.OperationCancelled.rawValue, userInfo: nil)
-//                self.finishOnCallbackQueue(error: cancelError)
-//            }
-//            
+            if(self.isCancelled){
+                return
+            }
             if let error = error {
                 self.finish(error: error)
                 return
@@ -52,11 +52,11 @@ public class CKDiscoverAllUserIdentitiesOperation : CKOperation {
                     // Parse JSON into CKRecords
                     for userDictionary in userDictionaries {
                         
-                        if let userIdenity = CKUserIdentity(dictionary: userDictionary) {
-                            self.discoveredIdentities.append(userIdenity)
+                        if let userIdentity = CKUserIdentity(dictionary: userDictionary) {
+                            self.discoveredIdentities.append(userIdentity)
                             
-                            // Call RecordCallback
-                            self.userIdentityDiscoveredBlock?(userIdenity)
+                            // Call discovered callback
+                            self.discovered(userIdentity: userIdentity)
                             
                         } else {
                             

--- a/Sources/CKFetchRecordZonesOperation.swift
+++ b/Sources/CKFetchRecordZonesOperation.swift
@@ -73,14 +73,10 @@ public class CKFetchRecordZonesOperation : CKDatabaseOperation {
         
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url, parameters: request) { (dictionary, error) in
 
-// shouldnt be needed
-//            if self.isCancelled {
-//                // Send Cancelled Error to CompletionBlock
-//                let cancelError = NSError(domain: CKErrorDomain, code: CKErrorCode.OperationCancelled.rawValue, userInfo: nil)
-//                self.finishOnCallbackQueue(error: cancelError)
-//            }
-            
-            if let error = error {
+            if(self.isCancelled){
+                return
+            }
+            else if let error = error {
                 self.finish(error: error)
                 return
             } else if let dictionary = dictionary {

--- a/Sources/CKFetchSubscriptionsOperation.swift
+++ b/Sources/CKFetchSubscriptionsOperation.swift
@@ -50,6 +50,7 @@ public class CKFetchSubscriptionsOperation : CKDatabaseOperation {
         
         super.finishOnCallbackQueue(error: error)
     }
+
     
     override func performCKOperation() {
         
@@ -63,7 +64,10 @@ public class CKFetchSubscriptionsOperation : CKDatabaseOperation {
         
         
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url, parameters: request) { (dictionary, networkError) in
-            if let error = networkError {
+            if(self.isCancelled){
+                return
+            }
+            else if let error = networkError {
                 
                 self.finish(error: error)
                 

--- a/Sources/CKLocation.swift
+++ b/Sources/CKLocation.swift
@@ -149,7 +149,8 @@ extension CKLocationType {
         "altitude": NSNumber(value: altitude),
         "speed": NSNumber(value: speed),
         "course": NSNumber(value: course),
-        "timestamp": NSNumber(value: UInt(timestamp.timeIntervalSince1970))
+        // CKWebServicesReference doesn't say if this should be seconds or milliseconds, assuming millis since thats what TIMESTAMP uses.
+        "timestamp": NSNumber(value: UInt64(timestamp.timeIntervalSince1970 * 1000))
         ]
     }
 }

--- a/Sources/CKModifyRecordZonesOperation.swift
+++ b/Sources/CKModifyRecordZonesOperation.swift
@@ -98,9 +98,7 @@ public class CKModifyRecordZonesOperation : CKDatabaseOperation {
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url, parameters: request) { (dictionary, error) in
             
             if self.isCancelled {
-                // Send Cancelled Error to CompletionBlock
-                let cancelError = NSError(domain: CKErrorDomain, code: CKErrorCode.OperationCancelled.rawValue, userInfo: nil)
-                self.finishOnCallbackQueue(error: cancelError)
+                return
             }
             
             if let error = error {

--- a/Sources/CKModifySubscriptionsOperation.swift
+++ b/Sources/CKModifySubscriptionsOperation.swift
@@ -48,6 +48,9 @@ public class CKModifySubscriptionsOperation : CKDatabaseOperation {
         let subscriptionURLRequest = CKModifySubscriptionsURLRequest(subscriptionsToSave: subscriptionsToSave, subscriptionIDsToDelete: subscriptionIDsToDelete)
         subscriptionURLRequest.completionBlock = {
             (result) in
+            if(self.isCancelled){
+                return
+            }
             switch result {
             case .success(let dictionary):
                 

--- a/Sources/CKOperation.swift
+++ b/Sources/CKOperation.swift
@@ -78,7 +78,9 @@ public class CKOperation: Operation {
             return;
         }
         
-        main()
+        callbackQueue.async {
+            self.main()
+        }
     }
     
     func addAndRun(childOperation: CKOperation) {
@@ -95,10 +97,11 @@ public class CKOperation: Operation {
         if !isCancelled {
             do {
                 try CKOperationShouldRun()
+                performCKOperation()
             } catch {
-                finish(error: error)
+                // since main is called on callback queue we can finish directly
+                finishOnCallbackQueue(error: error)
             }
-            performCKOperation()
         }
     }
     

--- a/Sources/CKPublishAssetsOperation.swift
+++ b/Sources/CKPublishAssetsOperation.swift
@@ -17,17 +17,24 @@ public class CKPublishAssetsOperation : CKOperation {
     public var assetPublishedBlock: ((CKAsset?, Error?) -> Void)?
 
     override func finishOnCallbackQueue(error: Error?) {
-
+        if(error == nil){
+            // build partial error
+        }
+        
+        // call assets completion block
+        
+        super.finishOnCallbackQueue(error: error)
     }
     
     
     override func performCKOperation() {
-       
+       //self.finish(error: error or nil)
     }
     
     init(assets: [CKAsset]) {
         self.assets = assets
         
     }
+    
 }
 

--- a/Sources/CKRecord.swift
+++ b/Sources/CKRecord.swift
@@ -155,13 +155,13 @@ public class CKRecord: NSObject {
         // Parse Created Dictionary
         if let createdDictionary = recordDictionary[CKRecordDictionary.created] as? [String: Any], let created = CKRecordLog(dictionary: createdDictionary) {
             self.creatorUserRecordID = CKRecordID(recordName: created.userRecordName)
-            self.creationDate = NSDate(timeIntervalSince1970: created.timestamp)
+            self.creationDate = NSDate(timeIntervalSince1970: Double(created.timestamp) / 1000)
         }
         
         // Parse Modified Dictionary
         if let modifiedDictionary = recordDictionary[CKRecordDictionary.modified] as? [String: Any], let modified = CKRecordLog(dictionary: modifiedDictionary) {
             self.lastModifiedUserRecordID = CKRecordID(recordName: modified.userRecordName)
-            self.modificationDate = NSDate(timeIntervalSince1970: modified.timestamp)
+            self.modificationDate = NSDate(timeIntervalSince1970: Double(modified.timestamp) / 1000)
         }
         
         // Enumerate Fields
@@ -202,12 +202,12 @@ struct CKValueType {
 }
 
 struct CKRecordLog {
-    let timestamp: TimeInterval
+    let timestamp: UInt64 // milliseconds
     let userRecordName: String
     let deviceID: String
     
     init?(dictionary: [String: Any]) {
-        guard let timestamp = (dictionary["timestamp"] as? NSNumber)?.doubleValue, let userRecordName = dictionary["userRecordName"] as? String, let deviceID =  dictionary["deviceID"] as? String else {
+        guard let timestamp = (dictionary["timestamp"] as? NSNumber)?.uint64Value, let userRecordName = dictionary["userRecordName"] as? String, let deviceID =  dictionary["deviceID"] as? String else {
             return nil
         }
         
@@ -272,7 +272,7 @@ extension CKRecord {
     static func process(number: NSNumber, type: String) -> CKRecordValue {
         switch(type) {
         case "TIMESTAMP":
-            return NSDate(timeIntervalSince1970: number.doubleValue)
+            return NSDate(timeIntervalSince1970: number.doubleValue / 1000)
         default:
             return number
         }
@@ -340,8 +340,8 @@ extension CKRecord {
                    // let stringArray =  array.bridge() as! [String]
                     return array.bridge()
                 case "TIMESTAMP_LIST":
-                    let dateArray = (array as! [NSNumber]).map({ (dateInterval) -> NSDate in
-                        return  NSDate(timeIntervalSince1970: dateInterval.doubleValue)
+                    let dateArray = (array as! [NSNumber]).map({ (timestamp) -> NSDate in
+                        return  NSDate(timeIntervalSince1970: timestamp.doubleValue / 1000)
                     })
                     return NSArray(array: dateArray)
                     

--- a/Sources/CKRegisterTokenOperation.swift
+++ b/Sources/CKRegisterTokenOperation.swift
@@ -16,6 +16,8 @@ class CKRegisterTokenOperation : CKOperation {
     
     var tokenInfo: CKPushTokenInfo?
     
+    public var registerTokenCompletionBlock: ((CKPushTokenInfo?, Error?) -> Void)?
+    
     init(apnsEnvironment:CKEnvironment, apnsToken: Data) {
         
         self.apnsEnvironment = apnsEnvironment
@@ -32,12 +34,13 @@ class CKRegisterTokenOperation : CKOperation {
         super.finishOnCallbackQueue(error: error)
     }
     
-    public var registerTokenCompletionBlock: ((CKPushTokenInfo?, Error?) -> Void)?
-    
     override func performCKOperation() {
         
         let request = CKTokenRegistrationURLRequest(token: apnsToken, apnsEnvironment: "\(apnsEnvironment)")
         request.completionBlock = { (result) in
+            if(self.isCancelled){
+                return
+            }
             switch result {
             case .success(let dictionary):
                 self.tokenInfo = CKPushTokenInfo(dictionaryRepresentation: dictionary)
@@ -46,8 +49,6 @@ class CKRegisterTokenOperation : CKOperation {
             case .error(let error):
                 self.finish(error: error.error)
             }
-            
-            
         }
         
         request.performRequest()

--- a/Sources/CKTokenCreateURLRequest.swift
+++ b/Sources/CKTokenCreateURLRequest.swift
@@ -81,7 +81,9 @@ class CKTokenCreateOperation: CKOperation {
         request.requestProperties = bodyDictionaryRepresentation
         
         request.completionBlock = { result in
-            
+            if(self.isCancelled){
+                return
+            }
             switch result {
             case .success(let dictionary):
                 self.info = CKPushTokenInfo(dictionaryRepresentation: dictionary)!

--- a/Sources/CKURLRequest.swift
+++ b/Sources/CKURLRequest.swift
@@ -34,8 +34,6 @@ class CKURLRequest: NSObject {
     var accountInfoProvider: CKAccountInfoProvider?
     
     var databaseScope: CKDatabaseScope = .public
-    
-    var delegateQueue : OperationQueue?
 
     var dateRequestWentOut: Date?
     

--- a/Sources/CKURLRequest.swift
+++ b/Sources/CKURLRequest.swift
@@ -33,9 +33,9 @@ class CKURLRequest: NSObject {
     
     var accountInfoProvider: CKAccountInfoProvider?
     
-    var isCancelled: Bool = false
-    
     var databaseScope: CKDatabaseScope = .public
+    
+    var delegateQueue : OperationQueue?
 
     var dateRequestWentOut: Date?
     
@@ -165,6 +165,8 @@ class CKURLRequest: NSObject {
     
     func performRequest() {
         dateRequestWentOut = Date()
+        
+        // maybe could have passed in CKOperation's callbackQueue as the delegateQueue, would have simplified the code
         let session = URLSession(configuration: sessionConfiguration, delegate: self, delegateQueue: nil)
 
         urlSessionTask = session.dataTask(with: request)
@@ -173,7 +175,7 @@ class CKURLRequest: NSObject {
     }
     
     func cancel() {
-        isCancelled = true
+        urlSessionTask?.cancel()
     }
     
     func requestDidParseNodeFailure() {}


### PR DESCRIPTION
PR for issue #11

Note that these changes come from the same fork as my previous PR, since changes had been made to your master while I was working I had to merge in those changes using [Syncing a Fork](https://help.github.com/articles/syncing-a-fork/) from Github help, which is what the Merges commit is.

And issue #2 for converting NSDate to and from millisecond TIMESTAMPS either multiplying or dividing by 1000. creationDate and modificationDate now have correct values.