### PR TITLE
Fix memory leaks; update travis file; building on linux

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,12 +9,11 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         DIR="$(pwd)";
         cd ..;
-        export SWIFT_VERSION=4.0.3        
+        export SWIFT_VERSION=4.0.3;
         wget https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         tar xzf swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         export PATH="${PWD}/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04/usr/bin:${PATH}";
         cd "$DIR";
     fi
-else
   - swift package update
   - swift build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ sudo: required
 dist: trusty
 osx_image: xcode9.2
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux"]]; then curl -sL https://apt.vapor.sh/ci; sudo apt-get -q install swift; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux"]]; then sudo apt-get install swift; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -sL https://apt.vapor.sh/ci; sudo apt-get -q install swift; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -q swift; fi
   - cd src
   - swift package update
   - swift build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         DIR="$(pwd)";
         cd ..;
-        export SWIFT_VERSION=3.2;
+        export SWIFT_VERSION=4.0.3;
         wget https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         tar xzf swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         export PATH="${PWD}/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04/usr/bin:${PATH}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         DIR="$(pwd)";
         cd ..;
-        export SWIFT_VERSION=3.1.1;
+        export SWIFT_VERSION=3.1;
         wget https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         tar xzf swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         export PATH="${PWD}/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04/usr/bin:${PATH}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         DIR="$(pwd)";
         cd ..;
-        export SWIFT_VERSION=3.0.2;
+        export SWIFT_VERSION=3.2;
         wget https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         tar xzf swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         export PATH="${PWD}/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04/usr/bin:${PATH}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,5 @@ sudo: required
 dist: trusty
 osx_image: xcode8
 script:
-  - eval "$(curl -sL https://swift.vapor.sh/ci)"
+  - eval "$(curl -sL https://apt.vapor.sh/ci)"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,15 @@ sudo: required
 dist: trusty
 osx_image: xcode9.2
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -sL https://apt.vapor.sh/ci; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=~/swift/usr/bin:"${PATH}"; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
+        DIR="$(pwd)";
+        cd ..;
+        export SWIFT_VERSION=4.0.3        
+        wget https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
+        tar xzf swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
+        export PATH="${PWD}/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04/usr/bin:${PATH}";
+        cd "$DIR";
+    fi
+else
   - swift package update
   - swift build

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,7 @@ sudo: required
 dist: trusty
 osx_image: xcode9.2
 script:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -sL https://apt.vapor.sh/ci; sudo apt-get -q install swift; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -q swift; fi
-  - cd src
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then curl -sL https://apt.vapor.sh/ci; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then export PATH=~/swift/usr/bin:"${PATH}"; fi
   - swift package update
   - swift build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         DIR="$(pwd)";
         cd ..;
-        export SWIFT_VERSION=4.0.3;
+        export SWIFT_VERSION=3.1.1;
         wget https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         tar xzf swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         export PATH="${PWD}/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04/usr/bin:${PATH}";

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,10 @@ os:
 language: generic
 sudo: required
 dist: trusty
-osx_image: xcode8
+osx_image: xcode9.2
 script:
-  - eval "$(curl -sL https://apt.vapor.sh/ci)"
-
+  - if [[ "$TRAVIS_OS_NAME" == "linux"]]; then curl -sL https://apt.vapor.sh/ci; sudo apt-get -q install swift; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux"]]; then sudo apt-get install swift; fi
+  - cd src
+  - swift package update
+  - swift build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
         DIR="$(pwd)";
         cd ..;
-        export SWIFT_VERSION=3.1;
+        export SWIFT_VERSION=3.0.2;
         wget https://swift.org/builds/swift-${SWIFT_VERSION}-release/ubuntu1404/swift-${SWIFT_VERSION}-RELEASE/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         tar xzf swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04.tar.gz;
         export PATH="${PWD}/swift-${SWIFT_VERSION}-RELEASE-ubuntu14.04/usr/bin:${PATH}";

--- a/Sources/CKAcceptSharesOperation.swift
+++ b/Sources/CKAcceptSharesOperation.swift
@@ -44,8 +44,8 @@ public class CKAcceptSharesOperation: CKOperation {
         
         operationURLRequest.accountInfoProvider = CloudKit.shared.defaultAccount
         
-        operationURLRequest.completionBlock = { (result) in
-            if(self.isCancelled){
+        operationURLRequest.completionBlock = { [weak self] (result) in
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             switch result {
@@ -56,15 +56,15 @@ public class CKAcceptSharesOperation: CKOperation {
                     // Parse JSON into CKRecords
                     for resultDictionary in resultsDictionary {
                         if let shareMetadata = CKShareMetadata(dictionary: resultDictionary) {
-                            self.perShare(shareMetadata: shareMetadata, acceptedShare: nil, error: nil)
+                            strongSelf.perShare(shareMetadata: shareMetadata, acceptedShare: nil, error: nil)
                         }
                     }
                 }
                 
-                self.finish(error: nil)
+                strongSelf.finish(error: nil)
                 
             case .error(let error):
-                self.finish(error: error.error)
+                strongSelf.finish(error: error.error)
             }
         }
         

--- a/Sources/CKDiscoverAllUserIdentitiesOperation.swift
+++ b/Sources/CKDiscoverAllUserIdentitiesOperation.swift
@@ -40,13 +40,13 @@ public class CKDiscoverAllUserIdentitiesOperation : CKOperation {
       
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url) { [weak self] (dictionary, error) in
             
-            guard self != nil, !self!.isCancelled else {
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             
             var returnError = error
             defer {
-                self?.finish(error: returnError)
+                strongSelf.finish(error: returnError)
             }
             
             guard let dictionary = dictionary,
@@ -60,10 +60,10 @@ public class CKDiscoverAllUserIdentitiesOperation : CKOperation {
             for userDictionary in userDictionaries {
                 
                 if let userIdentity = CKUserIdentity(dictionary: userDictionary) {
-                    self?.discoveredIdentities.append(userIdentity)
+                    strongSelf.discoveredIdentities.append(userIdentity)
                     
                     // Call discovered callback
-                    self?.discovered(userIdentity: userIdentity)
+                    strongSelf.discovered(userIdentity: userIdentity)
                     
                 } else {
                     

--- a/Sources/CKDownloadAssetsOperation.swift
+++ b/Sources/CKDownloadAssetsOperation.swift
@@ -48,7 +48,7 @@ public class CKDownloadAssetsOperation: CKDatabaseOperation {
             // Create URLSessionDownloadTasks
             for asset in assetsToDownload {
                 if let downloadURL = asset.downloadURL {
-                    print("URL: \(downloadURL.absoluteString)")
+                    CloudKit.debugPrint("URL: \(downloadURL.absoluteString)")
                     // Create request for download URL
                     let downloadRequest = URLRequest(url: downloadURL)
                     // Create download task
@@ -134,7 +134,7 @@ extension CKDownloadAssetsOperation: URLSessionDownloadDelegate {
     public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         let downloadTask = task as! URLSessionDownloadTask
         
-        print(task.currentRequest?.url?.absoluteString as Any)
+        CloudKit.debugPrint(task.currentRequest?.url?.absoluteString as Any)
         guard let currentAsset = assetsByDownloadTask[downloadTask] else {
             fatalError("Asset should belong to completed download task")
         }
@@ -166,7 +166,7 @@ extension CKDownloadAssetsOperation: URLSessionDownloadDelegate {
             let filename = NSUUID().uuidString
             let destinationURL = URL(fileURLWithPath: "\(temporaryDirectory)\(filename)")
             
-            print(destinationURL)
+            CloudKit.debugPrint(destinationURL)
         
             let fileManager = FileManager.default
             do {
@@ -177,7 +177,7 @@ extension CKDownloadAssetsOperation: URLSessionDownloadDelegate {
             do {
                 try fileManager.copyItem(at: location, to: destinationURL)
             } catch let error as NSError {
-                print("Could not copy downloaded asset file to disk: \(error.localizedDescription)")
+                CloudKit.debugPrint("Could not copy downloaded asset file to disk: \(error.localizedDescription)")
                 completed(asset: currentAsset, error: error)
                 return
             }

--- a/Sources/CKDownloadAssetsOperation.swift
+++ b/Sources/CKDownloadAssetsOperation.swift
@@ -176,7 +176,7 @@ extension CKDownloadAssetsOperation: URLSessionDownloadDelegate {
             
             do {
                 try fileManager.copyItem(at: location, to: destinationURL)
-            } catch let error as NSError {
+            } catch let error {
                 CloudKit.debugPrint("Could not copy downloaded asset file to disk: \(error.localizedDescription)")
                 completed(asset: currentAsset, error: error)
                 return

--- a/Sources/CKFetchRecordZonesOperation.swift
+++ b/Sources/CKFetchRecordZonesOperation.swift
@@ -73,12 +73,12 @@ public class CKFetchRecordZonesOperation : CKDatabaseOperation {
         
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url, parameters: request) { [weak self] (dictionary, error) in
             
-            guard self != nil, !self!.isCancelled else {
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             
             defer {
-                self?.finish(error: error)
+                strongSelf.finish(error: error)
             }
             
             guard let dictionary = dictionary,
@@ -92,11 +92,11 @@ public class CKFetchRecordZonesOperation : CKDatabaseOperation {
             for zoneDictionary in zoneDictionaries {
                 
                 if let zone = CKRecordZone(dictionary: zoneDictionary) {
-                    self?.recordZoneByZoneID[zone.zoneID] = zone
+                    strongSelf.recordZoneByZoneID[zone.zoneID] = zone
                 } else if let fetchError = CKFetchErrorDictionary<CKRecordZoneID>(dictionary: zoneDictionary) {
                     
                     // Append Error
-                    self?.recordZoneErrors[fetchError.identifier] = fetchError.error()
+                    strongSelf.recordZoneErrors[fetchError.identifier] = fetchError.error()
                 }
             }
         }

--- a/Sources/CKFetchRecordsOperation.swift
+++ b/Sources/CKFetchRecordsOperation.swift
@@ -87,12 +87,12 @@ public class CKFetchRecordsOperation: CKDatabaseOperation {
         
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url, parameters: request) { [weak self] (dictionary, error) in
             
-            guard self != nil, !self!.isCancelled else {
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             
             defer {
-                self?.finish(error: error)
+                strongSelf.finish(error: error)
             }
             
             guard let dictionary = dictionary,
@@ -106,15 +106,15 @@ public class CKFetchRecordsOperation: CKDatabaseOperation {
             for (index,recordDictionary) in recordsDictionary.enumerated() {
                 
                 // Call Progress Block, this is hacky support and not the callbacks intented purpose
-                let progress = Double(index + 1) / Double((self?.recordIDs!.count)!)
-                let recordID = self?.recordIDs![index]
-                self?.progressed(recordID: recordID!, progress: progress)
+                let progress = Double(index + 1) / Double((strongSelf.recordIDs!.count))
+                let recordID = strongSelf.recordIDs![index]
+                strongSelf.progressed(recordID: recordID, progress: progress)
                 
                 if let record = CKRecord(recordDictionary: recordDictionary) {
-                    self?.recordIDsToRecords[record.recordID] = record
+                    strongSelf.recordIDsToRecords[record.recordID] = record
                     
                     // Call per record callback, not to be confused with finished
-                    self?.completed(record: record, recordID: record.recordID, error: nil)
+                    strongSelf.completed(record: record, recordID: record.recordID, error: nil)
                     
                 } else {
                     
@@ -122,7 +122,7 @@ public class CKFetchRecordsOperation: CKDatabaseOperation {
                     let error = NSError(domain: CKErrorDomain, code: CKErrorCode.PartialFailure.rawValue, userInfo: [NSLocalizedDescriptionKey: "Failed to parse record from server".bridge()])
                     
                     // Call per record callback, not to be confused with finished
-                    self?.completed(record: nil, recordID: nil, error: error)
+                    strongSelf.completed(record: nil, recordID: nil, error: error)
                     
                     // todo add to recordErrors array
                     

--- a/Sources/CKFetchSubscriptionsOperation.swift
+++ b/Sources/CKFetchSubscriptionsOperation.swift
@@ -65,12 +65,12 @@ public class CKFetchSubscriptionsOperation : CKDatabaseOperation {
         
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url, parameters: request) { [weak self] (dictionary, networkError) in
             
-            guard self != nil, !self!.isCancelled else {
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             
             defer {
-                self?.finish(error: networkError)
+                strongSelf.finish(error: networkError)
             }
             
             guard let dictionary = dictionary,
@@ -84,14 +84,14 @@ public class CKFetchSubscriptionsOperation : CKDatabaseOperation {
                 
                 if let subscription = CKSubscription(dictionary: subscriptionDictionary) {
                     // Append Record
-                    self?.subscriptionsIDToSubscriptions[subscription.subscriptionID] = subscription
+                    strongSelf.subscriptionsIDToSubscriptions[subscription.subscriptionID] = subscription
                     
                 }  else if let subscriptionFetchError = CKSubscriptionFetchErrorDictionary(dictionary: subscriptionDictionary) {
                     
                     let errorCode = CKErrorCode.errorCode(serverError: subscriptionFetchError.serverErrorCode)!
                     let error = NSError(domain: CKErrorDomain, code: errorCode.rawValue, userInfo: [NSLocalizedDescriptionKey: subscriptionFetchError.reason])
                     
-                    self?.subscriptionErrors[subscriptionFetchError.subscriptionID] = error
+                    strongSelf.subscriptionErrors[subscriptionFetchError.subscriptionID] = error
                     
                 } else {
                     fatalError("Couldn't resolve record or record fetch error dictionary")

--- a/Sources/CKModifyRecordZonesOperation.swift
+++ b/Sources/CKModifyRecordZonesOperation.swift
@@ -97,12 +97,12 @@ public class CKModifyRecordZonesOperation : CKDatabaseOperation {
         
         urlSessionTask = CKWebRequest(container: operationContainer).request(withURL: url, parameters: request) { [weak self] (dictionary, error) in
             
-            guard self != nil, !self!.isCancelled else {
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             
             defer {
-                self?.finish(error: error)
+                strongSelf.finish(error: error)
             }
             
             guard let dictionary = dictionary,
@@ -114,11 +114,11 @@ public class CKModifyRecordZonesOperation : CKDatabaseOperation {
             // Parse JSON into CKRecords
             for zoneDictionary in zoneDictionaries {
                 if let zone = CKRecordZone(dictionary: zoneDictionary) {
-                    self?.recordZonesByZoneIDs[zone.zoneID] = zone
+                    strongSelf.recordZonesByZoneIDs[zone.zoneID] = zone
                 } else if let fetchError = CKFetchErrorDictionary<CKRecordZoneID>(dictionary: zoneDictionary) {
                     
                     // Append Error
-                    self?.recordZoneErrors[fetchError.identifier] = fetchError.error()
+                    strongSelf.recordZoneErrors[fetchError.identifier] = fetchError.error()
                 }
             }
         }

--- a/Sources/CKModifyRecordsOperation.swift
+++ b/Sources/CKModifyRecordsOperation.swift
@@ -194,30 +194,30 @@ public class CKModifyRecordsOperation: CKDatabaseOperation {
         
         request.completionBlock = { [weak self] (result) in
             
-            guard self != nil, !self!.isCancelled else {
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             
             switch result {
             case .error(let error):
-                self?.modifyRecordsCompletionBlock?(nil, nil, error.error)
+                strongSelf.modifyRecordsCompletionBlock?(nil, nil, error.error)
             case .success(let dictionary):
                 
                 // Process Records
                 if let recordsDictionary = dictionary["records"] as? [[String: Any]] {
                     
-                    self?.savedRecords = [CKRecord]()
-                    self?.deletedRecordIDs = [CKRecordID]()
+                    strongSelf.savedRecords = [CKRecord]()
+                    strongSelf.deletedRecordIDs = [CKRecordID]()
                     // Parse JSON into CKRecords
                     for recordDictionary in recordsDictionary {
                         
                         if let record = CKRecord(recordDictionary: recordDictionary) {
                             // Append Record
                             //self.recordsByRecordIDs[record.recordID] = record
-                            self?.savedRecords?.append(record)
+                            strongSelf.savedRecords?.append(record)
                             
                             // Call RecordCallback
-                            self?.completed(record: record, error: nil)
+                            strongSelf.completed(record: record, error: nil)
                             
                         } else if let recordFetchError = CKRecordFetchErrorDictionary(dictionary: recordDictionary) {
                             
@@ -226,10 +226,10 @@ public class CKModifyRecordsOperation: CKDatabaseOperation {
                             let recordName = recordDictionary["recordName"] as! String
                             let recordID = CKRecordID(recordName: recordName) // todo: get zone from dictionary
                             
-                            self?.recordErrors[recordID] = error
+                            strongSelf.recordErrors[recordID] = error
                             
                             // todo the original record should be passed in here, that is probably what the self.recordsByRecordIDs was for
-                            self?.completed(record: nil, error: error)
+                            strongSelf.completed(record: nil, error: error)
                         } else {
                             
                             if let _ = recordDictionary["recordName"],
@@ -237,7 +237,7 @@ public class CKModifyRecordsOperation: CKDatabaseOperation {
                                 
                                 let recordName = recordDictionary["recordName"] as! String
                                 let recordID = CKRecordID(recordName: recordName) // todo: get zone from dictionary
-                                self?.deletedRecordIDs?.append(recordID)
+                                strongSelf.deletedRecordIDs?.append(recordID)
                                 
                                 
                             } else {
@@ -249,7 +249,7 @@ public class CKModifyRecordsOperation: CKDatabaseOperation {
             }
             
             // Mark operation as complete
-            self?.finish(error: nil)
+            strongSelf.finish(error: nil)
             
         }
         

--- a/Sources/CKModifySubscriptionsOperation.swift
+++ b/Sources/CKModifySubscriptionsOperation.swift
@@ -46,9 +46,8 @@ public class CKModifySubscriptionsOperation : CKDatabaseOperation {
     override func performCKOperation() {
         
         let subscriptionURLRequest = CKModifySubscriptionsURLRequest(subscriptionsToSave: subscriptionsToSave, subscriptionIDsToDelete: subscriptionIDsToDelete)
-        subscriptionURLRequest.completionBlock = {
-            (result) in
-            if(self.isCancelled){
+        subscriptionURLRequest.completionBlock = { [weak self] (result) in
+            guard self != nil, !self!.isCancelled else {
                 return
             }
             switch result {
@@ -62,10 +61,10 @@ public class CKModifySubscriptionsOperation : CKDatabaseOperation {
                         
                         if let subscription = CKSubscription(dictionary: subscriptionDictionary) {
                             // Append Record
-                            self.subscriptions.append(subscription)
+                            self?.subscriptions.append(subscription)
                             
                         } else if let subscriptionID = subscriptionDictionary["subscriptionID"] as? String {
-                            self.deletedSubscriptionIDs.append(subscriptionID)
+                            self?.deletedSubscriptionIDs.append(subscriptionID)
                             
                         } else if let subscriptionFetchError = CKSubscriptionFetchErrorDictionary(dictionary: subscriptionDictionary) {
                             
@@ -81,9 +80,9 @@ public class CKModifySubscriptionsOperation : CKDatabaseOperation {
                     }
                 }
                 
-                self.finish(error: nil)
+                self?.finish(error: nil)
             case .error(let error):
-                self.finish(error: error.error)
+                self?.finish(error: error.error)
             }
         }
         

--- a/Sources/CKModifySubscriptionsOperation.swift
+++ b/Sources/CKModifySubscriptionsOperation.swift
@@ -47,7 +47,7 @@ public class CKModifySubscriptionsOperation : CKDatabaseOperation {
         
         let subscriptionURLRequest = CKModifySubscriptionsURLRequest(subscriptionsToSave: subscriptionsToSave, subscriptionIDsToDelete: subscriptionIDsToDelete)
         subscriptionURLRequest.completionBlock = { [weak self] (result) in
-            guard self != nil, !self!.isCancelled else {
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             switch result {
@@ -61,10 +61,10 @@ public class CKModifySubscriptionsOperation : CKDatabaseOperation {
                         
                         if let subscription = CKSubscription(dictionary: subscriptionDictionary) {
                             // Append Record
-                            self?.subscriptions.append(subscription)
+                            strongSelf.subscriptions.append(subscription)
                             
                         } else if let subscriptionID = subscriptionDictionary["subscriptionID"] as? String {
-                            self?.deletedSubscriptionIDs.append(subscriptionID)
+                            strongSelf.deletedSubscriptionIDs.append(subscriptionID)
                             
                         } else if let subscriptionFetchError = CKSubscriptionFetchErrorDictionary(dictionary: subscriptionDictionary) {
                             
@@ -80,9 +80,9 @@ public class CKModifySubscriptionsOperation : CKDatabaseOperation {
                     }
                 }
                 
-                self?.finish(error: nil)
+                strongSelf.finish(error: nil)
             case .error(let error):
-                self?.finish(error: error.error)
+                strongSelf.finish(error: error.error)
             }
         }
         

--- a/Sources/CKOperation.swift
+++ b/Sources/CKOperation.swift
@@ -55,7 +55,7 @@ public class CKOperation: Operation {
         
         // Check if operation is already cancelled
         if isCancelled && isFinished {
-            print("Not starting already cancelled operation \(self)")
+            CloudKit.debugPrint("Not starting already cancelled operation \(self)")
             return
         }
  
@@ -144,7 +144,7 @@ public class CKOperation: Operation {
             return
         }
         
-        print("The operation operation \(self) didn't start or is already finished")
+        CloudKit.debugPrint("The operation operation \(self) didn't start or is already finished")
     }
     
 

--- a/Sources/CKPushConnection.swift
+++ b/Sources/CKPushConnection.swift
@@ -37,7 +37,7 @@ class CKPushConnection: NSObject, URLSessionDataDelegate {
         // Serialize JSON
         do {
             if let json = try JSONSerialization.jsonObject(with: data, options: []) as? [String: Any] {
-                print(json)
+                CloudKit.debugPrint(json)
                 // Create Notification
                 if let notification = CKNotification.notification(fromRemoteNotificationDictionary: json) {
                     callBack?(notification)
@@ -57,7 +57,7 @@ class CKPushConnection: NSObject, URLSessionDataDelegate {
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         if let error = error {
-            print(error)
+            CloudKit.debugPrint(error)
         }
         
         // Restart Task

--- a/Sources/CKQueryOperation.swift
+++ b/Sources/CKQueryOperation.swift
@@ -74,8 +74,8 @@ public class CKQueryOperation: CKDatabaseOperation {
         queryOperationURLRequest.accountInfoProvider = CloudKit.shared.defaultAccount
         queryOperationURLRequest.databaseScope = database?.scope ?? .public
         
-        queryOperationURLRequest.completionBlock = { (result) in
-            if(self.isCancelled){
+        queryOperationURLRequest.completionBlock = { [weak self] (result) in
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             switch result {
@@ -91,7 +91,7 @@ public class CKQueryOperation: CKDatabaseOperation {
                     #endif
                     
                     if let data = data {
-                        self.resultsCursor = CKQueryCursor(data: data, zoneID: CKRecordZoneID(zoneName: "_defaultZone", ownerName: ""))
+                        strongSelf.resultsCursor = CKQueryCursor(data: data, zoneID: CKRecordZoneID(zoneName: "_defaultZone", ownerName: ""))
                     }
                 }
                 
@@ -103,19 +103,19 @@ public class CKQueryOperation: CKDatabaseOperation {
                         
                         if let record = CKRecord(recordDictionary: recordDictionary) {
                             // Call RecordCallback
-                            self.fetched(record: record)
+                            strongSelf.fetched(record: record)
                         } else {
                             // Create Error
                             // Invalid state to be in, this operation normally doesnt provide partial errors
                             let error = NSError(domain: CKErrorDomain, code: CKErrorCode.PartialFailure.rawValue, userInfo: [NSLocalizedDescriptionKey: "Failed to parse record from server"])
-                            self.finish(error: error)
+                            strongSelf.finish(error: error)
                             return
                         }
                     }
                 }
-                self.finish(error: nil)
+                strongSelf.finish(error: nil)
             case .error(let error):
-                self.finish(error: error.error)
+                strongSelf.finish(error: error.error)
             }
         }
         

--- a/Sources/CKRecord.swift
+++ b/Sources/CKRecord.swift
@@ -230,7 +230,7 @@ extension CKRecord {
             }
         }
         
-        print(fieldsDictionary)
+        CloudKit.debugPrint(fieldsDictionary)
 
         
         return fieldsDictionary

--- a/Sources/CKRegisterTokenOperation.swift
+++ b/Sources/CKRegisterTokenOperation.swift
@@ -44,7 +44,7 @@ class CKRegisterTokenOperation : CKOperation {
             switch result {
             case .success(let dictionary):
                 strongSelf.tokenInfo = CKPushTokenInfo(dictionaryRepresentation: dictionary)
-                print(dictionary)
+                CloudKit.debugPrint(dictionary)
                 strongSelf.finish(error: nil)
             case .error(let error):
                 strongSelf.finish(error: error.error)

--- a/Sources/CKRegisterTokenOperation.swift
+++ b/Sources/CKRegisterTokenOperation.swift
@@ -37,17 +37,17 @@ class CKRegisterTokenOperation : CKOperation {
     override func performCKOperation() {
         
         let request = CKTokenRegistrationURLRequest(token: apnsToken, apnsEnvironment: "\(apnsEnvironment)")
-        request.completionBlock = { (result) in
-            if(self.isCancelled){
+        request.completionBlock = { [weak self] (result) in
+            guard self != nil, !self!.isCancelled else {
                 return
             }
             switch result {
             case .success(let dictionary):
-                self.tokenInfo = CKPushTokenInfo(dictionaryRepresentation: dictionary)
+                self?.tokenInfo = CKPushTokenInfo(dictionaryRepresentation: dictionary)
                 print(dictionary)
-                self.finish(error: nil)
+                self?.finish(error: nil)
             case .error(let error):
-                self.finish(error: error.error)
+                self?.finish(error: error.error)
             }
         }
         

--- a/Sources/CKRegisterTokenOperation.swift
+++ b/Sources/CKRegisterTokenOperation.swift
@@ -38,16 +38,16 @@ class CKRegisterTokenOperation : CKOperation {
         
         let request = CKTokenRegistrationURLRequest(token: apnsToken, apnsEnvironment: "\(apnsEnvironment)")
         request.completionBlock = { [weak self] (result) in
-            guard self != nil, !self!.isCancelled else {
+            guard let strongSelf = self, !strongSelf.isCancelled else {
                 return
             }
             switch result {
             case .success(let dictionary):
-                self?.tokenInfo = CKPushTokenInfo(dictionaryRepresentation: dictionary)
+                strongSelf.tokenInfo = CKPushTokenInfo(dictionaryRepresentation: dictionary)
                 print(dictionary)
-                self?.finish(error: nil)
+                strongSelf.finish(error: nil)
             case .error(let error):
-                self?.finish(error: error.error)
+                strongSelf.finish(error: error.error)
             }
         }
         

--- a/Sources/CKServerRequestAuth.swift
+++ b/Sources/CKServerRequestAuth.swift
@@ -64,7 +64,7 @@ struct CKServerRequestAuth {
                     fatalError("Error occured while signing \(error)")
                 }
             } else {
-                print(error)
+                CloudKit.debugPrint(error)
                 return nil
             }
         }

--- a/Sources/CKURLRequest.swift
+++ b/Sources/CKURLRequest.swift
@@ -169,7 +169,7 @@ class CKURLRequest: NSObject {
 
         urlSessionTask = session.dataTask(with: request)
         urlSessionTask!.resume()
-        
+        session.finishTasksAndInvalidate()
     }
     
     func cancel() {

--- a/Sources/CKURLRequest.swift
+++ b/Sources/CKURLRequest.swift
@@ -227,7 +227,7 @@ extension CKURLRequest: URLSessionDataDelegate {
     
     func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
         if let error = error {
-            print(error)
+            CloudKit.debugPrint(error)
             // Handle Error
             completionBlock?(.error(.network(error)))
         }

--- a/Sources/CKURLRequest.swift
+++ b/Sources/CKURLRequest.swift
@@ -209,7 +209,7 @@ extension CKURLRequest: URLSessionDataDelegate {
                 completionBlock?(result)
             }
         
-        } catch let error as NSError {
+        } catch let error {
             completionBlock?(.error(.parse(error)))
         }
     }

--- a/Sources/CKWebRequest.swift
+++ b/Sources/CKWebRequest.swift
@@ -101,7 +101,7 @@ class CKWebRequest {
                 
                 
                 let dataString = NSString(data: data, encoding: String.Encoding.utf8.rawValue)
-                print(dataString as Any)
+                CloudKit.debugPrint(dataString as Any)
                 let dictionary = try! JSONSerialization.jsonObject(with: data, options: []) as! [String: Any]
                 
                 if let httpResponse = response as? HTTPURLResponse {
@@ -134,7 +134,7 @@ class CKWebRequest {
         var components = URLComponents(url: url, resolvingAgainstBaseURL: false)
        
         components?.queryItems = authQueryItems
-        print(components?.path as Any)
+        CloudKit.debugPrint(components?.path as Any)
         guard let requestURL = components?.url else {
             return nil
         }
@@ -171,7 +171,7 @@ class CKWebRequest {
         // Build URL
         var components = URLComponents(string: url)
         components?.queryItems = authQueryItems
-        print(components?.path as Any)
+        CloudKit.debugPrint(components?.path as Any)
         guard let requestURL = components?.url else {
             return nil
         }
@@ -192,7 +192,7 @@ class CKWebRequest {
         // Build URL
         var components = URLComponents(string: url)
         components?.queryItems = authQueryItems
-        print(components?.path as Any)
+        CloudKit.debugPrint(components?.path as Any)
         guard let requestURL = components?.url else {
             return nil
         }


### PR DESCRIPTION
- The `URLSession` object in `CKURLRequest` was not calling `finishTasksAndInvalidate()`, which causes a memory leak. `URLSession` holds a strong reference to the delegate, and if it's not cleaned up then each session instance stays around forever. From the docs:

> Important
The session object keeps a strong reference to the delegate until your app exits or explicitly invalidates the session. If you don’t invalidate the session, your app leaks memory until it exits.

- Operations had retain cycles in their completion closures (missing `[weak self]` capture list)
- Fix travis file
- Build on linux